### PR TITLE
Fix not found table with database prefix

### DIFF
--- a/Model/ResourceModel/Menu/Node/Collection.php
+++ b/Model/ResourceModel/Menu/Node/Collection.php
@@ -43,17 +43,19 @@ class Collection extends AbstractCollection
     protected function _initSelect()
     {
         parent::_initSelect();
-
+    
         if (!$this->scopeConfig->isSetFlag(Menu::XML_SNOWMENU_GENERAL_CUSTOMER_GROUPS)) {
             return $this;
         }
-
+    
+        $customerTable = $this->getTable('snowmenu_customer');
+    
         $this->getSelect()->joinLeft(
-            ['customer' => 'snowmenu_customer'],
+            ['customer' => $customerTable],
             'main_table.node_id = customer.node_id',
             ['customer_groups' => new Expression('GROUP_CONCAT(group_id SEPARATOR \',\')')]
         )->group('main_table.node_id');
-
+    
         return $this;
     }
 }


### PR DESCRIPTION
When clicking the "Create Menu" button, an error occurs on Magento installations that are using a database table prefix.   This happens because the table name in the join statement was hardcoded without including the prefix.

```
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento.snowmenu_customer' doesn't exist, query was: SELECT `main_table`.*, GROUP_CONCAT(group_id SEPARATOR ',') AS `customer_groups` FROM `cb_snowmenu_node` AS `main_table` LEFT JOIN `snowmenu_customer` AS `customer` ON main_table.node_id = customer.node_id WHERE (menu_id='') GROUP BY `main_table`.`node_id` ORDER BY level ASC, parent_id ASC, position ASC
```
